### PR TITLE
Fix MSVS command line build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,8 +159,8 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANGCC OR CMAKE_COMPILER_IS_IC
     # Turn on all warnings
     if(CMAKE_COMPILER_IS_ICC)
         list(APPEND OSD_COMPILER_OPTIONS -w2 -wd1572 -wd1418 -wd981 -wd383 -wd193 -wd444)
-    else()
-        list(APPEND OSD_COMPILER_OPTIONS -Wall -Wextra)
+    #else()
+    #    list(APPEND OSD_COMPILER_OPTIONS -Wall -Wextra)
     endif()
 
     # HBR uses the offsetof macro on a templated struct, which appears

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,8 +159,8 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANGCC OR CMAKE_COMPILER_IS_IC
     # Turn on all warnings
     if(CMAKE_COMPILER_IS_ICC)
         list(APPEND OSD_COMPILER_OPTIONS -w2 -wd1572 -wd1418 -wd981 -wd383 -wd193 -wd444)
-    #else()
-    #    list(APPEND OSD_COMPILER_OPTIONS -Wall -Wextra)
+    else()
+        list(APPEND OSD_COMPILER_OPTIONS -Wall -Wextra)
     endif()
 
     # HBR uses the offsetof macro on a templated struct, which appears
@@ -217,7 +217,7 @@ elseif(MSVC)
     # Turn on all warnings
     list(APPEND OSD_COMPILER_OPTIONS /Wall
         /W3     # Use warning level recommended for production purposes.
-        /WX     # Treat all compiler warnings as errors.
+        #/WX     # Treat all compiler warnings as errors.
         # warning C4005: macro redefinition
         /wd4005
         # these warnings are being triggered from inside VC's header files


### PR DESCRIPTION
Turn off warning messages which are treated as build failures.